### PR TITLE
fix: ios devices env test regexp

### DIFF
--- a/src/core/mobile.ts
+++ b/src/core/mobile.ts
@@ -5,7 +5,7 @@ import { Result } from "../types/common";
  * @returns 检测当前环境是否是iOS
  */
 export const isIOS = () => {
-  return /(iPhone|iPad|iPod|iOS)/i.test(navigator.userAgent);
+  return /(iPhone|iPad|iPod|iOS|Macintosh)/i.test(navigator.userAgent);
 };
 
 /**

--- a/src/core/mobile.ts
+++ b/src/core/mobile.ts
@@ -5,7 +5,8 @@ import { Result } from "../types/common";
  * @returns 检测当前环境是否是iOS
  */
 export const isIOS = () => {
-  return /(iPhone|iPad|iPod|iOS|Macintosh)/i.test(navigator.userAgent);
+  return /(iPhone|iPad|iPod|iOS)/i.test(navigator.userAgent) ||
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
 };
 
 /**


### PR DESCRIPTION
Apple has changed the user agent of their devices, especially the iPad series, so adding compatibility checks would be better.